### PR TITLE
Fix: Ajout de la branche steven2 au workflow de déploiement docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - steven2
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'


### PR DESCRIPTION
- Le workflow ne se déclenchait que sur main
- Ajout de steven2 pour permettre le déploiement depuis cette branche
- Correction du problème 404 sur GitHub Pages